### PR TITLE
Replace platform specific delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,13 @@ Yes, if you can do that... then great! Windows 10’s version 1607 update, dubbe
 
 However, if you want to support older Windows versions, then you might consider using `cross-env` or another approach to leverage environment variables in your scripts.
 </details>
+
+<details>
+  <summary>Platform specific delimiter variables like `PATH`?</summary>
+`$:` will be replaced with `;` or `:` depending on your platform.
+
+Example:
+```
+cross-var cross-env NODE_PATH=$NODE_PATH$:test mocha --recursive
+```
+</details>

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,10 @@ import { exec } from "child_process";
 function normalize( args, isWindows ) {
     return args.map( arg => {
         Object.keys( process.env ).forEach( key => {
-            const regex = new RegExp( `\\$${ key }|%${ key }%`, "i" );
-            arg = arg.replace( regex, process.env[ key ] );
+            const isWin32 = os.platform() === 'win32';
+            arg = arg.replace( /\$:/g, isWin32 ? ';' : ':' );
+            const reg = new RegExp( `\\$${ key }|%${ key }%`, 'gi' );
+            arg = arg.replace( reg, process.env[ key ] );
         } );
         return arg;
     } )


### PR DESCRIPTION
Resolve #3 

`$:` will be replaced with `;` or `:` depending on your platform.

Example:
```
cross-var cross-env NODE_PATH=$NODE_PATH$:test mocha --recursive
```

Windows: `%NODE_PATH%;test`
Linux: `$NODE_PATH:test`