### PR TITLE
Bug: multiple params on a single line are not replaced.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import exit from 'exit';
 function normalize( args, isWindows ) {
     return args.map( arg => {
         Object.keys( process.env ).forEach( key => {
-            const regex = new RegExp( `\\$${ key }|%${ key }%`, "i" );
+            const regex = new RegExp( `\\$${ key }|%${ key }%`, "ig" );
             arg = arg.replace( regex, process.env[ key ] );
         } );
         return arg;


### PR DESCRIPTION
Repro:

```
cross-var echo \"npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push --tags\"
```

Before fix:
```
npm run build && npm test && git commit -am 1.0.1 && git tag $npm_package_version && git push --tags
                    replaced as expected ---^^^^^            ^^^^^^^^^^^^^^^^^^^^--- should be replaced!
```
After fix: 
```
npm run build && npm test && git commit -am 1.0.1 && git tag 1.0.1 && git push --tags
```