### PR TITLE
Sort vars by descending length to prevent partial replacement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,13 @@ import exit from 'exit';
 
 function normalize( args, isWindows ) {
     return args.map( arg => {
-        Object.keys( process.env ).forEach( key => {
-            const regex = new RegExp( `\\$${ key }|%${ key }%`, "ig" );
-            arg = arg.replace( regex, process.env[ key ] );
-        } );
+        Object
+            .keys( process.env )
+            .sort( ( x, y ) => x.length < y.length ) // sort by descending length to prevent partial replacement
+            .forEach( key => {
+                const regex = new RegExp( `\\$${ key }|%${ key }%`, "ig" );
+                arg = arg.replace( regex, process.env[ key ] );
+            } );
         return arg;
     } )
 }


### PR DESCRIPTION
Fixes #8 