### PR TITLE
Bugfix for Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,15 @@ import os from "os";
 import { exec } from "child_process";
 import exit from 'exit';
 
-function normalize( args ) {
-    const isWindows = (process.platform.substr(0, 3) === "win");
+function normalize( args, isWindows ) {
     return args.map( arg => {
         Object.keys( process.env )
             .sort( ( x, y ) => x.length < y.length ) // sort by descending length to prevent partial replacement
             .forEach( key => {
-                const regex = new RegExp( `\\$${ key }|%${ key }%`, "ig" );
-                arg = arg.replace( regex, process.env[ key ] );
+                const regex = new RegExp( `\\$(\\w+)|%(\\w+)%`, "ig" );
+                const name = (arg.split(regex) !== null) ? arg.split(regex)[1] : undefined
+                const value = (process.env[name] === undefined) ? '' : process.env[name];
+                arg = arg.replace(regex, value);
             } );
         return arg;
     } )

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,15 @@ import spawn from "cross-spawn";
 import os from "os";
 import { exec } from "child_process";
 import exit from 'exit';
+const isWindows = (process.platform.substr(0, 3) === "win");
 
-function normalize( args, isWindows ) {
+function normalize( args ) {
+    const isWindows = (process.platform.substr(0, 3) === "win");
     return args.map( arg => {
-        Object.keys( process.env ).forEach( key => {
-            const regex = new RegExp( `\\$${ key }|%${ key }%`, "i" );
-            arg = arg.replace( regex, process.env[ key ] );
-        } );
+        const regex = new RegExp( `\\$(\\w+)|%(\\w+)%`, "i" );
+        const key = (arg.match(regex) !== null) ? arg.match(regex)[1] : undefined;
+        const value = (isWindows && process.env[key] === undefined) ? '' : process.env[key];
+        arg = arg.replace(regex, value);
         return arg;
     } )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import spawn from "cross-spawn";
 import os from "os";
 import { exec } from "child_process";
 import exit from 'exit';
-const isWindows = (process.platform.substr(0, 3) === "win");
 
 function normalize( args ) {
     const isWindows = (process.platform.substr(0, 3) === "win");


### PR DESCRIPTION
If a variable doesn't exist on windows, it would always return the variable name as a string (e.g. $npm_config_build). On Linux/OSX on the other hand an empty string is returned.

I now tried to fix this, by checking if the variable exists and replace the variable on windows with an empty string.
