### PR TITLE
Use more specific regex for babel-register

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@
 
 require( "babel-register" )( {
     ignore: false,
-    only: /src/
+    only: /cross-var\/src/
 } );
 require( "./src/index.js" );


### PR DESCRIPTION
Make regex more specific so that clients can use the library in a folder with "src" in the name