### PR TITLE
Array.prototype.sort compareFunction expects a number to be returned.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import exit from 'exit';
 function normalize( args, isWindows ) {
     return args.map( arg => {
         Object.keys( process.env )
-            .sort( ( x, y ) => x.length < y.length ) // sort by descending length to prevent partial replacement
+            .sort( ( x, y ) => y.length - x.length ) // sort by descending length to prevent partial replacement
             .forEach( key => {
                 const regex = new RegExp( `\\$${ key }|%${ key }%`, "ig" );
                 arg = arg.replace( regex, process.env[ key ] );


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
This was causing a buggy behaviour when variable names were substrings of other variable names.

Example:
JSON.stringify(["hola", "holab", "ho"].sort( ( x, y ) => false )) === JSON.stringify(["hola", "holab", "ho"].sort( ( x, y ) => true ))